### PR TITLE
chore: bump version to 0.0.5 with notarization support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-usage-tracker-for-mac",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Claude Codeの使用料金を可視化する Mac用のメニューバーアプリケーション",
   "main": "dist/main.js",
   "scripts": {
@@ -44,6 +44,7 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "identity": "Ayahito Nakamura (52BYYDA79X)",
+      "notarize": true,
       "target": [
         {
           "target": "dmg",


### PR DESCRIPTION
This pull request updates the `package.json` file to increment the application version and enable notarization for macOS builds.

Version update:

* Updated the `version` field from `0.0.4` to `0.0.5` to reflect the new release. (`[package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)`)

Build configuration enhancement:

* Added `"notarize": true` under the macOS build settings to enable app notarization, improving security and compliance for macOS distributions. (`[package.jsonR47](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R47)`)