### PR TITLE
Fix ccusage ES module import issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "canvas": "3.1.0",
-        "ccusage": "0.8.0"
+        "ccusage": "0.5.0"
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -1725,9 +1725,9 @@
       }
     },
     "node_modules/ccusage": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/ccusage/-/ccusage-0.8.0.tgz",
-      "integrity": "sha512-m/BrmMExMX/KwfnShN35VR7g5ePolEIF5tF/AJ8dS8eNB2fNu2LQ7hGbn/qaDR4c8Xi66kwwJmxhm37X5sFYPA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ccusage/-/ccusage-0.5.0.tgz",
+      "integrity": "sha512-8nPp/EVKcKiYgXeJ7V5mgdn2flg1mqnFgJlcUq8v7TqgJDDTWEr1uIv3bEChinep9eMeZWyfNuJazdU5RzJxTA==",
       "license": "MIT",
       "bin": {
         "ccusage": "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "claude-usage-tracker-for-mac",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-usage-tracker-for-mac",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "canvas": "3.1.0",
-        "ccusage": "0.5.0"
+        "ccusage": "0.8.0"
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
@@ -1725,9 +1725,9 @@
       }
     },
     "node_modules/ccusage": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ccusage/-/ccusage-0.5.0.tgz",
-      "integrity": "sha512-8nPp/EVKcKiYgXeJ7V5mgdn2flg1mqnFgJlcUq8v7TqgJDDTWEr1uIv3bEChinep9eMeZWyfNuJazdU5RzJxTA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ccusage/-/ccusage-0.8.0.tgz",
+      "integrity": "sha512-m/BrmMExMX/KwfnShN35VR7g5ePolEIF5tF/AJ8dS8eNB2fNu2LQ7hGbn/qaDR4c8Xi66kwwJmxhm37X5sFYPA==",
       "license": "MIT",
       "bin": {
         "ccusage": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "canvas": "3.1.0",
-    "ccusage": "0.5.0"
+    "ccusage": "0.8.0"
   },
   "build": {
     "appId": "com.penicillin0.claude-usage-tracker",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "claude-usage-tracker-for-mac",
   "version": "0.0.7",
   "description": "Claude Codeの使用料金を可視化する Mac用のメニューバーアプリケーション",
+  "type": "module",
   "main": "dist/main.js",
   "scripts": {
     "build": "tsc",
@@ -30,7 +31,7 @@
   },
   "dependencies": {
     "canvas": "3.1.0",
-    "ccusage": "0.8.0"
+    "ccusage": "0.5.0"
   },
   "build": {
     "appId": "com.penicillin0.claude-usage-tracker",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { app } from "electron";
-import { TrayManager } from "./tray";
+import { TrayManager } from "./tray.js";
 
 const trayManager = new TrayManager();
 

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -1,12 +1,15 @@
 import { Menu, type MenuItemConstructorOptions, Tray, app } from "electron";
 import * as path from "node:path";
-import type { UsageData } from "./types";
-import { getUserUsage } from "./usage";
+import { fileURLToPath } from "node:url";
+import type { UsageData } from "./types.js";
+import { getUserUsage } from "./usage.js";
 
 export class TrayManager {
   private tray: Tray | null = null;
 
   async initializeTray(): Promise<void> {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
     const iconPath = path.join(__dirname, "..", "assets", "icon.png");
 
     try {

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,15 +1,9 @@
-import type { UsageData } from "./types";
+import { calculateTotals, createTotalsObject } from "ccusage/calculate-cost";
+import { loadUsageData } from "ccusage/data-loader";
+import type { UsageData } from "./types.js";
 
 export async function getUserUsage(): Promise<UsageData> {
   try {
-    // Dynamic import for ESM module
-    // @ts-ignore - dynamic import of ESM module
-    const { loadUsageData } = await import("ccusage/data-loader");
-    const { calculateTotals, createTotalsObject } = await import(
-      // @ts-ignore - dynamic import of ESM module
-      "ccusage/calculate-cost"
-    );
-
     const today = new Date().toISOString().slice(0, 10).replace(/-/g, "");
 
     // Get today's usage data

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,9 +26,9 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs" /* Specify what module code is generated. */,
+    "module": "node16" /* Specify what module code is generated. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
-    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    "moduleResolution": "node16" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
## Summary
• Fixed ES module import issues with ccusage package after upgrading to v0.5.0
• Updated TypeScript configuration to properly support ES modules with Node16 module resolution
• Resolved runtime errors related to module loading and __dirname usage

## Changes Made
• **TypeScript Configuration**: Updated to use Node16 module system and module resolution
• **Package Configuration**: Added `"type": "module"` to package.json for proper ES module support
• **Import Paths**: Added explicit `.js` extensions for local imports as required by ES modules
• **ES Module Compatibility**: Replaced `__dirname` with `fileURLToPath(import.meta.url)` equivalent
• **ccusage Integration**: Fixed import paths to use package exports correctly without `/dist/` prefix

## Test Plan
- [x] Application builds successfully with `npm run build`
- [x] Linting passes with `npm run lint`
- [x] ES module imports resolve correctly
- [ ] Manual testing of tray application functionality
- [ ] Verify usage data loading works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)