### PR TITLE
chore: bump version to 0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-usage-tracker-for-mac",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Claude Codeの使用料金を可視化する Mac用のメニューバーアプリケーション",
   "type": "module",
   "main": "dist/main.js",


### PR DESCRIPTION
This pull request includes a version bump in the `package.json` file to prepare for a new release.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.0.7` to `0.0.8` to reflect the upcoming release.